### PR TITLE
update to TibiaData API v4

### DIFF
--- a/get-stats.mjs
+++ b/get-stats.mjs
@@ -7,7 +7,7 @@ const slugify = (name) => {
 
 const getWorlds = async () => {
 	console.log('Getting list of Tibia worlds…');
-	const response = await fetch('https://api.tibiadata.com/v3/worlds');
+	const response = await fetch('https://api.tibiadata.com/v4/worlds');
 	const data = await response.json();
 	const regularWorlds = data.worlds.regular_worlds;
 	const worldNames = regularWorlds.map((world) => world.name);
@@ -16,7 +16,7 @@ const getWorlds = async () => {
 
 const getKillStatsForWorld = async (worldName) => {
 	try {
-		const response = await fetch(`https://api.tibiadata.com/v3/killstatistics/${slugify(worldName)}`);
+		const response = await fetch(`https://api.tibiadata.com/v4/killstatistics/${slugify(worldName)}`);
 		const data = await response.json();
 		console.log(`Processing kill stats for world ${worldName}…`);
 		return data;


### PR DESCRIPTION
TibiaData API v3 is deprecated and will be removed soon.

Link:
https://tibiadata.com/2024/01/tibiadata-api-v3-has-been-deprecated/

rel f8efe97c65da5685cb7e8e622af66f73502a4b47
rel afb6856c921f3ef6a72011e695b3df00bddebd2d